### PR TITLE
Add CloudWatch alert for Redis database usage

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -46,3 +46,47 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 }
 */
 
+resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning" {
+  count = var.redis_clusters
+
+  alarm_name          = "Warning-${var.name}-${var.env}-CacheCluster00${count.index + 1}-DatabaseMemoryUsageHigh"
+  alarm_description   = "Warning: Redis memory usage is at or above ${var.warning_database_usage_threshold}%. Please check and consider resizing the instance"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+
+  threshold           = var.warning_database_usage_threshold
+
+  alarm_actions       = [var.sns_topic_arn]
+  ok_actions          = [var.sns_topic_arn]
+
+  dimensions {
+    CacheClusterId = "${aws_elasticache_replication_group.redis.id}-00${count.index + 1}"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-critical" {
+  count = var.redis_clusters
+
+  alarm_name          = "Critical-${var.name}-${var.env}-CacheCluster00${count.index + 1}-DatabaseMemoryUsageHigh"
+  alarm_description   = "Critical: Redis memory usage is at or above ${var.critical_database_usage_threshold}%. Immediate action is required. Notify the developers and consider resizing the instance immediately."
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "DatabaseMemoryUsagePercentage"
+  namespace           = "AWS/ElastiCache"
+  period              = "300"
+  statistic           = "Average"
+
+  threshold           = var.critical_database_usage_threshold
+
+  alarm_actions       = [var.sns_topic_arn]
+  ok_actions          = [var.sns_topic_arn]
+
+  dimensions {
+    CacheClusterId = "${aws_elasticache_replication_group.redis.id}-00${count.index + 1}"
+  }
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,23 @@ variable "alarm_actions" {
 }
 */
 
+variable "warning_database_usage_threshold" {
+  description = "The threshold for warning level database usage alarm"
+  type        = number
+  default     = 90
+}
+
+variable "critical_database_usage_threshold" {
+  description = "The threshold for critical level database usage alarm"
+  type        = number
+  default     = 96
+}
+
+variable "sns_topic_arn" {
+  type        = string
+  description = "The SNS topic ARN to notify."
+}
+
 variable "apply_immediately" {
   description = "Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is false."
   type        = bool


### PR DESCRIPTION
We are adding two alerts for CloudWatch: `redis-elasticache-high-db-memory-warning` and `redis-elasticache-high-db-memory-critical`.
`redis-elasticache-high-db-memory-warning` creates an alert at the warning level when Redis memory usage reaches or exceeds the threshold value of `${var.warning_database_usage_threshold}`%. Currently, this value is set to 90.
`redis-elasticache-high-db-memory-critical` creates an alert at the critical level when Redis memory usage reaches or exceeds the threshold value of `${var.critical_database_usage_threshold}`%. Currently, this value is set to 96.

[INSLY-2356][1]

[1]:https://app.clickup.com/t/2454960/INSLY-2356