### PR TITLE
 Fix the `dimensions`

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -63,7 +63,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning
   alarm_actions       = [var.sns_topic_arn]
   ok_actions          = [var.sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     CacheClusterId = "${aws_elasticache_replication_group.redis.id}-00${count.index + 1}"
   }
 }
@@ -85,7 +85,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-critica
   alarm_actions       = [var.sns_topic_arn]
   ok_actions          = [var.sns_topic_arn]
 
-  dimensions {
+  dimensions = {
     CacheClusterId = "${aws_elasticache_replication_group.redis.id}-00${count.index + 1}"
   }
 }


### PR DESCRIPTION
An error was detected during validation:
```
| Error: Unsupported block type
| on ...cloudwatch.tf line 66, in resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning":
| 66:   dimensions {
| Blocks of type "dimensions" are not expected here. Did you mean to define
|argument "dimensions"? If so, use the equals sign to assign it a value.
```

To fix it, the "=" symbol was added for `dimensions`.