### PR TITLE
Add the `alerts_enabled` variable

### DIFF
--- a/cloudwatch.tf
+++ b/cloudwatch.tf
@@ -47,7 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
 */
 
 resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning" {
-  count = var.redis_clusters
+  count = var.alerts_enabled == false ? 0 : var.redis_clusters
 
   alarm_name          = "Warning-${var.name}-${var.env}-CacheCluster00${count.index + 1}-DatabaseMemoryUsageHigh"
   alarm_description   = "Warning: Redis memory usage is at or above ${var.warning_database_usage_threshold}%. Please check and consider resizing the instance"
@@ -69,7 +69,7 @@ resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-warning
 }
 
 resource "aws_cloudwatch_metric_alarm" "redis-elasticache-high-db-memory-critical" {
-  count = var.redis_clusters
+  count = var.alerts_enabled == false ? 0 : var.redis_clusters
 
   alarm_name          = "Critical-${var.name}-${var.env}-CacheCluster00${count.index + 1}-DatabaseMemoryUsageHigh"
   alarm_description   = "Critical: Redis memory usage is at or above ${var.critical_database_usage_threshold}%. Immediate action is required. Notify the developers and consider resizing the instance immediately."

--- a/variables.tf
+++ b/variables.tf
@@ -27,8 +27,15 @@ variable "critical_database_usage_threshold" {
 }
 
 variable "sns_topic_arn" {
-  type        = string
   description = "The SNS topic ARN to notify."
+  type        = string
+  default     = null
+}
+
+variable "alerts_enabled" {
+  description = "Determines if alert-related resources should be created. When set to true, `sns_topic_arn` must be provided. When false, associated alerting resources are skipped."
+  type        = bool
+  default     = false
 }
 
 variable "apply_immediately" {


### PR DESCRIPTION
A variable called `alerts_enabled` was added to control the creation of resources. We check the value of the `alerts_enabled` variable. If it is equal to `false`, then `count` is set to `0`, which means that no resource instances will be created.
If the value of `alerts_enabled` is not equal to false, then `count` is set to the value of the `redis_clusters` variable.
Therefore, the number of resource instances created will depend on the value of the `redis_clusters` variable.

By default, the variable is set to false.

To use the variables in the module, they need to be defined.
Example:
```
module "redis-prj-beta" {
  source = "github.com/x-qdo/tf_aws_elasticache_redis.git?ref=xxxxx"

  ...
  alerts_enabled                    = true
  warning_database_usage_threshold  = 90
  critical_database_usage_threshold = 96
  sns_topic_arn                     = sns_arn
```