### PR TITLE
Update `aws_elasticache_replication_group`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Breaking changes
+
+In version 3.0.0, the module was reworked to operate with the 5.x.x version of the AWS provider.
+
 # A Terraform module to create a Redis ElastiCache cluster
 
 A terraform module providing a Redis ElastiCache cluster in AWS.
@@ -42,58 +46,97 @@ module "redis" {
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | n/a |
-| random | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.redis-elasticache-high-db-memory-critical](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.redis-elasticache-high-db-memory-warning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_elasticache_parameter_group.redis_parameter_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_parameter_group) | resource |
+| [aws_elasticache_replication_group.redis](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_replication_group) | resource |
+| [aws_elasticache_subnet_group.redis_subnet_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/elasticache_subnet_group) | resource |
+| [aws_security_group.redis_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.redis_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.redis_networks_ingress](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [random_id.salt](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allowed\_cidr | A list CIDRs to allow access to. | `list(string)` | <pre>[<br>  "127.0.0.1/32"<br>]</pre> | no |
-| allowed\_security\_groups | A list of Security Group ID's to allow access to. | `list(string)` | `[]` | no |
-| apply\_immediately | Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is false. | `bool` | `false` | no |
-| at\_rest\_encryption\_enabled | Whether to enable encryption at rest | `bool` | `false` | no |
-| auth\_token | The password used to access a password protected server. Can be specified only if transit\_encryption\_enabled = true. If specified must contain from 16 to 128 alphanumeric characters or symbols | `string` | `null` | no |
-| auto\_minor\_version\_upgrade | Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window | `bool` | `true` | no |
-| availability\_zones | A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important | `list(string)` | `[]` | no |
-| env | env to deploy into, should typically dev/staging/prod | `string` | n/a | yes |
-| kms\_key\_id | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if at\_rest\_encryption\_enabled = true | `string` | `""` | no |
-| name | Name for the Redis replication group i.e. UserObject | `string` | n/a | yes |
-| notification\_topic\_arn | An Amazon Resource Name (ARN) of an SNS topic to send ElastiCache notifications to. Example: arn:aws:sns:us-east-1:012345678999:my\_sns\_topic | `string` | `""` | no |
-| redis\_clusters | Number of Redis cache clusters (nodes) to create | `string` | n/a | yes |
-| redis\_failover | n/a | `bool` | `false` | no |
-| redis\_maintenance\_window | Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period | `string` | `"fri:08:00-fri:09:00"` | no |
-| redis\_node\_type | Instance type to use for creating the Redis cache clusters | `string` | `"cache.m3.medium"` | no |
-| redis\_parameters | additional parameters modifyed in parameter group | `list(map(any))` | `[]` | no |
-| redis\_port | n/a | `number` | `6379` | no |
-| redis\_snapshot\_retention\_limit | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot\_retention\_limit is not supported on cache.t1.micro or cache.t2.\* cache nodes | `number` | `0` | no |
-| redis\_snapshot\_window | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period | `string` | `"06:30-07:30"` | no |
-| redis\_version | Redis version to use, defaults to 3.2.10 | `string` | `"3.2.10"` | no |
-| security\_group\_names | A list of cache security group names to associate with this replication group | `list(string)` | `[]` | no |
-| snapshot\_arns | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my\_bucket/snapshot1.rdb | `list(string)` | `[]` | no |
-| snapshot\_name | The name of a snapshot from which to restore data into the new node group. Changing the snapshot\_name forces a new resource | `string` | `""` | no |
-| subnets | List of VPC Subnet IDs for the cache subnet group | `list(string)` | n/a | yes |
-| tags | Tags for redis nodes | `map(string)` | `{}` | no |
-| transit\_encryption\_enabled | Whether to enable encryption in transit. Requires 3.2.6 or >=4.0 redis\_version | `bool` | `false` | no |
-| vpc\_id | VPC ID | `string` | n/a | yes |
+| <a name="input_alerts_enabled"></a> [alerts\_enabled](#input\_alerts\_enabled) | Determines if alert-related resources should be created. When set to true, `sns_topic_arn` must be provided. When false, associated alerting resources are skipped. | `bool` | `false` | no |
+| <a name="input_allowed_cidr"></a> [allowed\_cidr](#input\_allowed\_cidr) | A list of Security Group ID's to allow access to. | `list(string)` | <pre>[<br>  "127.0.0.1/32"<br>]</pre> | no |
+| <a name="input_allowed_security_groups"></a> [allowed\_security\_groups](#input\_allowed\_security\_groups) | A list of Security Group ID's to allow access to. | `list(string)` | `[]` | no |
+| <a name="input_apply_immediately"></a> [apply\_immediately](#input\_apply\_immediately) | Specifies whether any modifications are applied immediately, or during the next maintenance window. Default is false. | `bool` | `false` | no |
+| <a name="input_at_rest_encryption_enabled"></a> [at\_rest\_encryption\_enabled](#input\_at\_rest\_encryption\_enabled) | Whether to enable encryption at rest | `bool` | `false` | no |
+| <a name="input_auth_token"></a> [auth\_token](#input\_auth\_token) | The password used to access a password protected server. Can be specified only if transit\_encryption\_enabled = true. If specified must contain from 16 to 128 alphanumeric characters or symbols | `string` | `null` | no |
+| <a name="input_auto_minor_version_upgrade"></a> [auto\_minor\_version\_upgrade](#input\_auto\_minor\_version\_upgrade) | Specifies whether a minor engine upgrades will be applied automatically to the underlying Cache Cluster instances during the maintenance window | `bool` | `true` | no |
+| <a name="input_availability_zones"></a> [availability\_zones](#input\_availability\_zones) | A list of EC2 availability zones in which the replication group's cache clusters will be created. The order of the availability zones in the list is not important | `list(string)` | `[]` | no |
+| <a name="input_critical_database_usage_threshold"></a> [critical\_database\_usage\_threshold](#input\_critical\_database\_usage\_threshold) | The threshold for critical level database usage alarm | `number` | `96` | no |
+| <a name="input_env"></a> [env](#input\_env) | env to deploy into, should typically dev/staging/prod | `string` | n/a | yes |
+| <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | The ARN of the key that you wish to use if encrypting at rest. If not supplied, uses service managed encryption. Can be specified only if at\_rest\_encryption\_enabled = true | `string` | `""` | no |
+| <a name="input_multi_az_enabled"></a> [multi\_az\_enabled](#input\_multi\_az\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_name"></a> [name](#input\_name) | Name for the Redis replication group i.e. UserObject | `string` | n/a | yes |
+| <a name="input_notification_topic_arn"></a> [notification\_topic\_arn](#input\_notification\_topic\_arn) | An Amazon Resource Name (ARN) of an SNS topic to send ElastiCache notifications to. Example: arn:aws:sns:us-east-1:012345678999:my\_sns\_topic | `string` | `""` | no |
+| <a name="input_redis_clusters"></a> [redis\_clusters](#input\_redis\_clusters) | Number of Redis cache clusters (nodes) to create | `string` | n/a | yes |
+| <a name="input_redis_failover"></a> [redis\_failover](#input\_redis\_failover) | n/a | `bool` | `false` | no |
+| <a name="input_redis_maintenance_window"></a> [redis\_maintenance\_window](#input\_redis\_maintenance\_window) | Specifies the weekly time range for when maintenance on the cache cluster is performed. The format is ddd:hh24:mi-ddd:hh24:mi (24H Clock UTC). The minimum maintenance window is a 60 minute period | `string` | `"fri:08:00-fri:09:00"` | no |
+| <a name="input_redis_node_type"></a> [redis\_node\_type](#input\_redis\_node\_type) | Instance type to use for creating the Redis cache clusters | `string` | `"cache.m3.medium"` | no |
+| <a name="input_redis_parameters"></a> [redis\_parameters](#input\_redis\_parameters) | additional parameters modifyed in parameter group | `list(map(any))` | `[]` | no |
+| <a name="input_redis_port"></a> [redis\_port](#input\_redis\_port) | n/a | `number` | `6379` | no |
+| <a name="input_redis_snapshot_retention_limit"></a> [redis\_snapshot\_retention\_limit](#input\_redis\_snapshot\_retention\_limit) | The number of days for which ElastiCache will retain automatic cache cluster snapshots before deleting them. For example, if you set SnapshotRetentionLimit to 5, then a snapshot that was taken today will be retained for 5 days before being deleted. If the value of SnapshotRetentionLimit is set to zero (0), backups are turned off. Please note that setting a snapshot\_retention\_limit is not supported on cache.t1.micro or cache.t2.* cache nodes | `number` | `0` | no |
+| <a name="input_redis_snapshot_window"></a> [redis\_snapshot\_window](#input\_redis\_snapshot\_window) | The daily time range (in UTC) during which ElastiCache will begin taking a daily snapshot of your cache cluster. The minimum snapshot window is a 60 minute period | `string` | `"06:30-07:30"` | no |
+| <a name="input_redis_version"></a> [redis\_version](#input\_redis\_version) | Redis version to use, defaults to 3.2.10 | `string` | `"3.2.10"` | no |
+| <a name="input_security_group_names"></a> [security\_group\_names](#input\_security\_group\_names) | A list of cache security group names to associate with this replication group | `list(string)` | `[]` | no |
+| <a name="input_snapshot_arns"></a> [snapshot\_arns](#input\_snapshot\_arns) | A single-element string list containing an Amazon Resource Name (ARN) of a Redis RDB snapshot file stored in Amazon S3. Example: arn:aws:s3:::my\_bucket/snapshot1.rdb | `list(string)` | `[]` | no |
+| <a name="input_snapshot_name"></a> [snapshot\_name](#input\_snapshot\_name) | The name of a snapshot from which to restore data into the new node group. Changing the snapshot\_name forces a new resource | `string` | `""` | no |
+| <a name="input_sns_topic_arn"></a> [sns\_topic\_arn](#input\_sns\_topic\_arn) | The SNS topic ARN to notify. | `string` | `null` | no |
+| <a name="input_subnets"></a> [subnets](#input\_subnets) | List of VPC Subnet IDs for the cache subnet group | `list(string)` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags for redis nodes | `map(string)` | `{}` | no |
+| <a name="input_transit_encryption_enabled"></a> [transit\_encryption\_enabled](#input\_transit\_encryption\_enabled) | Whether to enable encryption in transit. Requires 3.2.6 or >=4.0 redis\_version | `bool` | `false` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC ID | `string` | n/a | yes |
+| <a name="input_warning_database_usage_threshold"></a> [warning\_database\_usage\_threshold](#input\_warning\_database\_usage\_threshold) | The threshold for warning level database usage alarm | `number` | `90` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| endpoint | n/a |
-| id | n/a |
-| parameter\_group | n/a |
-| port | n/a |
-| redis\_security\_group\_id | n/a |
-| redis\_subnet\_group\_name | n/a |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | n/a |
+| <a name="output_id"></a> [id](#output\_id) | n/a |
+| <a name="output_parameter_group"></a> [parameter\_group](#output\_parameter\_group) | n/a |
+| <a name="output_port"></a> [port](#output\_port) | n/a |
+| <a name="output_redis_security_group_id"></a> [redis\_security\_group\_id](#output\_redis\_security\_group\_id) | n/a |
+| <a name="output_redis_subnet_group_name"></a> [redis\_subnet\_group\_name](#output\_redis\_subnet\_group\_name) | n/a |
+## Managed Resources
+* `aws_cloudwatch_metric_alarm.redis-elasticache-high-db-memory-critical` from `aws`
+* `aws_cloudwatch_metric_alarm.redis-elasticache-high-db-memory-warning` from `aws`
+* `aws_elasticache_parameter_group.redis_parameter_group` from `aws`
+* `aws_elasticache_replication_group.redis` from `aws`
+* `aws_elasticache_subnet_group.redis_subnet_group` from `aws`
+* `aws_security_group.redis_security_group` from `aws`
+* `aws_security_group_rule.redis_ingress` from `aws`
+* `aws_security_group_rule.redis_networks_ingress` from `aws`
+* `random_id.salt` from `random`
 
+## Data Resources
+* `data.aws_vpc.vpc` from `aws`
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## Authors

--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,8 @@ data "aws_vpc" "vpc" {
 }
 
 locals {
-  vpc_name = replace(lookup(data.aws_vpc.vpc.tags, "Name", var.vpc_id), ".", "-")
-  parameter_group_family = substr(var.redis_version, 0,1) < 6 || substr(var.redis_version, 0,1) >= 7 ? "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}": "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}.x"
+  vpc_name               = replace(lookup(data.aws_vpc.vpc.tags, "Name", var.vpc_id), ".", "-")
+  parameter_group_family = substr(var.redis_version, 0, 1) < 6 || substr(var.redis_version, 0, 1) >= 7 ? "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}" : "redis${replace(var.redis_version, "/\\.[\\d]+$/", "")}.x"
 }
 
 resource "random_id" "salt" {
@@ -15,33 +15,33 @@ resource "random_id" "salt" {
 }
 
 resource "aws_elasticache_replication_group" "redis" {
-  replication_group_id          = format("%.20s", "${var.name}-${var.env}")
-  replication_group_description = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${local.vpc_name}"
-  number_cache_clusters         = var.redis_clusters
-  node_type                     = var.redis_node_type
-  automatic_failover_enabled    = var.redis_failover
-  auto_minor_version_upgrade    = var.auto_minor_version_upgrade
-  availability_zones            = var.availability_zones
-  multi_az_enabled              = var.multi_az_enabled
-  engine                        = "redis"
-  at_rest_encryption_enabled    = var.at_rest_encryption_enabled
-  kms_key_id                    = var.kms_key_id
-  transit_encryption_enabled    = var.transit_encryption_enabled
-  auth_token                    = var.transit_encryption_enabled ? var.auth_token : null
-  engine_version                = var.redis_version
-  port                          = var.redis_port
-  parameter_group_name          = aws_elasticache_parameter_group.redis_parameter_group.id
-  subnet_group_name             = aws_elasticache_subnet_group.redis_subnet_group.id
-  security_group_names          = var.security_group_names
-  security_group_ids            = [aws_security_group.redis_security_group.id]
-  snapshot_arns                 = var.snapshot_arns
-  snapshot_name                 = var.snapshot_name
-  apply_immediately             = var.apply_immediately
-  maintenance_window            = var.redis_maintenance_window
-  notification_topic_arn        = var.notification_topic_arn
-  snapshot_window               = var.redis_snapshot_window
-  snapshot_retention_limit      = var.redis_snapshot_retention_limit
-  tags                          = merge(tomap({"Name" = format("tf-elasticache-%s-%s", var.name, local.vpc_name)}), var.tags)
+  replication_group_id        = format("%.20s", "${var.name}-${var.env}")
+  description                 = "Terraform-managed ElastiCache replication group for ${var.name}-${var.env}-${local.vpc_name}"
+  num_cache_clusters          = var.redis_clusters
+  node_type                   = var.redis_node_type
+  automatic_failover_enabled  = var.redis_failover
+  auto_minor_version_upgrade  = var.auto_minor_version_upgrade
+  preferred_cache_cluster_azs = var.availability_zones
+  multi_az_enabled            = var.multi_az_enabled
+  engine                      = "redis"
+  at_rest_encryption_enabled  = var.at_rest_encryption_enabled
+  kms_key_id                  = var.kms_key_id
+  transit_encryption_enabled  = var.transit_encryption_enabled
+  auth_token                  = var.transit_encryption_enabled ? var.auth_token : null
+  engine_version              = var.redis_version
+  port                        = var.redis_port
+  parameter_group_name        = aws_elasticache_parameter_group.redis_parameter_group.id
+  subnet_group_name           = aws_elasticache_subnet_group.redis_subnet_group.id
+  security_group_names        = var.security_group_names
+  security_group_ids          = [aws_security_group.redis_security_group.id]
+  snapshot_arns               = var.snapshot_arns
+  snapshot_name               = var.snapshot_name
+  apply_immediately           = var.apply_immediately
+  maintenance_window          = var.redis_maintenance_window
+  notification_topic_arn      = var.notification_topic_arn
+  snapshot_window             = var.redis_snapshot_window
+  snapshot_retention_limit    = var.redis_snapshot_retention_limit
+  tags                        = merge(tomap({ "Name" = format("tf-elasticache-%s-%s", var.name, local.vpc_name) }), var.tags)
 }
 
 resource "aws_elasticache_parameter_group" "redis_parameter_group" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+# Terraform version
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
+    }
+  }
+}


### PR DESCRIPTION
This commit updates the Terraform configuration for AWS ElastiCache replication group to align with the latest changes in the AWS provider.

Specifically, the following attribute changes were made:
- `replication_group_description` is replaced with `description`
- `number_cache_clusters` is replaced with `num_cache_clusters`
- `availability_zones` is replaced with `preferred_cache_cluster_azs`

These changes were introduced starting with version 5.0.0 of the AWS provider. More information can be found [here][1].

[1]: https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#500-may-25-2023